### PR TITLE
autosave page tree changes (no queue)

### DIFF
--- a/publishes/pages/resources/pages/components/PagesSidebar.vue
+++ b/publishes/pages/resources/pages/components/PagesSidebar.vue
@@ -36,7 +36,7 @@ type PageTree = Tree<Page>;
 
 const tree: PageTree = useTree<Page>(props.pages);
 
-tree.updateOnChange(() => props.pages);
+tree.updateOnChange(props.pages);
 
 const queueKey = `pages.order`;
 let originalOrder = useOriginal(tree.getOrder());
@@ -45,14 +45,8 @@ watch(
     tree,
     () => {
         const order = tree.getOrder();
-
-        if (originalOrder.matches(order)) {
-            saveQueue.remove(queueKey);
-        } else {
-            saveQueue.add(queueKey, async () => {
-                originalOrder.update(order);
-                Inertia.post('/admin/pages/order', { order });
-            });
+        if (!originalOrder.matches(order)) {
+            Inertia.post('/admin/pages/order', { order });
         }
     },
     { immediate: true, deep: true }


### PR DESCRIPTION
This PR enables auto saving the page tree instead of pushing a save job to the queue.

To prevent an endless request loop I had to change `tree.updateOnChange(() => props.pages)` back to `tree.updateOnChange(props.pages)`. Otherwise the orders would never actually match and always create a start a new save request.