### PR TITLE
Revert "autosave page tree changes (no queue)"

### DIFF
--- a/publishes/pages/resources/pages/components/PagesSidebar.vue
+++ b/publishes/pages/resources/pages/components/PagesSidebar.vue
@@ -36,7 +36,7 @@ type PageTree = Tree<Page>;
 
 const tree: PageTree = useTree<Page>(props.pages);
 
-tree.updateOnChange(props.pages);
+tree.updateOnChange(() => props.pages);
 
 const queueKey = `pages.order`;
 let originalOrder = useOriginal(tree.getOrder());
@@ -45,8 +45,14 @@ watch(
     tree,
     () => {
         const order = tree.getOrder();
-        if (!originalOrder.matches(order)) {
-            Inertia.post('/admin/pages/order', { order });
+
+        if (originalOrder.matches(order)) {
+            saveQueue.remove(queueKey);
+        } else {
+            saveQueue.add(queueKey, async () => {
+                originalOrder.update(order);
+                Inertia.post('/admin/pages/order', { order });
+            });
         }
     },
     { immediate: true, deep: true }


### PR DESCRIPTION
Reverts macramejs/admin-laravel#17

#17 breaks the updateOnChange when a new Page got added. Another solution for the "no queue" mehtod is therefore required.