### PR TITLE
Admin login request

### DIFF
--- a/publishes/admin/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/publishes/admin/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -3,8 +3,8 @@
 namespace {{ namespace }}\Http\Controllers\Auth;
 
 use {{ namespace }}\Ui\Page;
+use {{ namespace }}\Http\Requests\LoginRequest;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Auth\LoginRequest;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;

--- a/publishes/admin/app/Http/Requests/LoginRequest.php
+++ b/publishes/admin/app/Http/Requests/LoginRequest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 
-class LoginRequets extends FormRequest
+class LoginRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/publishes/admin/app/Http/Requests/LoginRequets.php
+++ b/publishes/admin/app/Http/Requests/LoginRequets.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Admin\Http\Requests;
+
+use App\Models\User;
+use Illuminate\Auth\Events\Lockout;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class LoginRequets extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'email'    => ['required', 'string', 'email'],
+            'password' => ['required', 'string'],
+        ];
+    }
+
+    /**
+     * Attempt to authenticate the request's credentials.
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function authenticate()
+    {
+        $this->ensureIsNotRateLimited();
+
+        // Load user from database
+        $user = User::where('email', $this->email)->first();
+
+        if (! $user || ! Hash::check($this->password, $user->password)) {
+            RateLimiter::hit($this->throttleKey());
+
+            throw ValidationException::withMessages([
+                'email' => trans('auth.failed'),
+            ]);
+        }
+
+        if (! $user->is_admin) {
+            RateLimiter::hit($this->throttleKey());
+
+            throw ValidationException::withMessages([
+                'email' => 'You are not authorized to access this area.',
+            ]);
+        }
+
+        Auth::login($user);
+
+        RateLimiter::clear($this->throttleKey());
+    }
+
+    /**
+     * Ensure the login request is not rate limited.
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function ensureIsNotRateLimited()
+    {
+        if (! RateLimiter::tooManyAttempts($this->throttleKey(), 5)) {
+            return;
+        }
+
+        event(new Lockout($this));
+
+        $seconds = RateLimiter::availableIn($this->throttleKey());
+
+        throw ValidationException::withMessages([
+            'email' => trans('auth.throttle', [
+                'seconds' => $seconds,
+                'minutes' => ceil($seconds / 60),
+            ]),
+        ]);
+    }
+
+    /**
+     * Get the rate limiting throttle key for the request.
+     *
+     * @return string
+     */
+    public function throttleKey()
+    {
+        return Str::lower($this->input('email')).'|'.$this->ip();
+    }
+}

--- a/src/Foundation/Console/MakeAdminCommand.php
+++ b/src/Foundation/Console/MakeAdminCommand.php
@@ -143,15 +143,6 @@ class MakeAdminCommand extends BaseMakeCommand
 
         $this->insertAfter($file, $insert, $after);
 
-        // Publish Laravel breeze's LoginRequest
-        if (! class_exists(\App\Http\Requests\Auth\LoginRequest::class)) {
-            $this->files->ensureDirectoryExists(app_path('Http/Requests/Auth'));
-            $this->files->copyDirectory(
-                base_path('vendor/laravel/breeze/stubs/default/App/Http/Requests/Auth'),
-                app_path('Http/Requests/Auth')
-            );
-        }
-
         // Add ResetPassword callback
         $appServiceProvider = app_path('Providers/AppServiceProvider.php');
         $insert = "


### PR DESCRIPTION
This PR adds a modified `LoginRequest` class instead of the default from Breeze.

Imagine the following scenario:

An application with frontend login for default users which also has a macrame admin backend. 
As a default user, trying to access the backend area i'd expect to be blocked right away, as I most certainly don't have the permission to access.

However, currently every user is able to login to the backend - if he has a valid login credentials. For sure - he will be blocked right away from the `AuthenticateAdmin` Middleware, so he won't be able to see anything. But he will be just redirected to a `403` page.

The login Request within this PR overrides the `authenticate` method, where by default the Auth facade just tries to do an `Auth::attempt` with the given credentials.

There is a way, to add another parameter to check if the user has a boolean flag `is_admin`, which would work for our purpose right at the moment. But by default it would fail with a the default error message "the credentials don't  mach our records" which can be seen as a feature or as misleading information. Also this method doesn't work if anything else than a boolean flag needs to be checked-

Instead of using the `Auth::attempt` we could use a manual credentials check and login which allows to check anything else on the use to determine if he should be allowed to login:

https://github.com/macramejs/admin-laravel/blob/6a01303a725b0b1942f0bbdf4ec54b91cd1df19a/publishes/admin/app/Http/Requests/LoginRequets.php#L46-L72

This could be any other check as well, as we have a full instance of the user:
https://github.com/macramejs/admin-laravel/blob/6a01303a725b0b1942f0bbdf4ec54b91cd1df19a/publishes/admin/app/Http/Requests/LoginRequets.php#L61

- wip
- new login request
