### PR TITLE
Add page settings tab

### DIFF
--- a/publishes/pages/app/controllers/{{ model }}Controller.php
+++ b/publishes/pages/app/controllers/{{ model }}Controller.php
@@ -2,17 +2,15 @@
 
 namespace Admin\Http\Controllers;
 
-use App\Models\Page;
-use Illuminate\Support\Str;
-use Illuminate\Http\Request;
-use Admin\Ui\Page as AdminPage;
 use Admin\Http\Indexes\PageIndex;
-use Illuminate\Http\RedirectResponse;
 use Admin\Http\Resources\PageResource;
-use Illuminate\Support\Facades\Redirect;
-use Macrame\Admin\Pages\Ui\PagesShowPage;
 use Admin\Http\Resources\PageTreeResource;
-use Macrame\Admin\Pages\Ui\PagesIndexPage;
+use Admin\Ui\Page as AdminPage;
+use App\Models\Page;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Str;
 
 class PageController
 {
@@ -48,12 +46,12 @@ class PageController
      * Show the page.
      *
      * @param {{ Model }} $page
-     * @param AdminPage $adminPage
+     * @param  AdminPage $adminPage
      * @return AdminPage
      */
     public function show(Page $page, AdminPage $adminPage, $tab = 'content')
     {
-        if (! in_array($tab, ['content', 'meta'])) {
+        if (! in_array($tab, ['content', 'meta', 'settings'])) {
             abort(404);
         }
 
@@ -69,16 +67,17 @@ class PageController
     /**
      * Update the page.
      *
-     * @param Request $request
-     * @param Page $page
+     * @param  Request $request
+     * @param  Page    $page
      * @return void
      */
     public function update(Request $request, Page $page)
     {
         $validated = $request->validate([
-            'content' => 'array',
+            'content'    => 'array',
             'attributes' => 'array',
-            'slug' => 'sometimes|string'
+            'slug'       => 'sometimes|string',
+            'name'       => 'sometimes|string',
         ]);
 
         // Enforce sluggified slug
@@ -94,8 +93,8 @@ class PageController
     /**
      * Update the meta information of the page.
      *
-     * @param Request $request
-     * @param Page $page
+     * @param  Request $request
+     * @param  Page    $page
      * @return void
      */
     public function meta(Request $request, Page $page)
@@ -117,16 +116,16 @@ class PageController
     /**
      * Store a new page.
      *
-     * @param Request $request
+     * @param  Request $request
      * @return void
      */
     public function store(Request $request)
     {
         $page = Page::make([
             'parent_id' => $request->parent,
-            'name'     => $request->name,
-            'slug'     => Str::slug($request->slug ?: $request->name),
-            'template' => $request->template,
+            'name'      => $request->name,
+            'slug'      => Str::slug($request->slug ?: $request->name),
+            'template'  => $request->template,
         ]);
 
         $page->creator_id = $request->user()->id;
@@ -141,8 +140,8 @@ class PageController
     /**
      * Destroy the given page.
      *
-     * @param Request $request
-     * @param Page $page
+     * @param  Request          $request
+     * @param  Page             $page
      * @return RedirectResponse
      */
     public function destroy(Request $request, Page $page)
@@ -155,7 +154,7 @@ class PageController
     /**
      * Update the order for of the page tree.
      *
-     * @param Request $request
+     * @param  Request $request
      * @return void
      */
     public function order(Request $request)

--- a/publishes/pages/resources/modules/helpers/index.ts
+++ b/publishes/pages/resources/modules/helpers/index.ts
@@ -1,7 +1,11 @@
-export const slugify = (str) => {
+export const slugify = str => {
     return str
         .toString()
         .toLowerCase()
+        .replace(/ä/g, 'ae')
+        .replace(/ö/g, 'oe')
+        .replace(/ü/g, 'ue')
+        .replace(/ß/g, 'ss')
         .replace(/\s+/g, '-') // Replace spaces with -
         .replace(/[^\w\-]+/g, '') // Remove all non-word chars
         .replace(/\-\-+/g, '-') // Replace multiple - with single -

--- a/publishes/pages/resources/modules/page/index.ts
+++ b/publishes/pages/resources/modules/page/index.ts
@@ -2,5 +2,7 @@ import { Inertia } from '@inertiajs/inertia';
 import { Page } from '@admin/types/resources';
 
 export const deletePage = async (page: Page) => {
-    Inertia.delete(`/admin/pages/${page.id}`);
+    if (confirm(`Are you sure you want to delete Page ${page.name}?`)) {
+        Inertia.delete(`/admin/pages/${page.id}`);
+    }
 };

--- a/publishes/pages/resources/pages/Show.vue
+++ b/publishes/pages/resources/pages/Show.vue
@@ -4,6 +4,9 @@
             <TabList>
                 <Tab :href="`/admin/pages/${page.data.id}`">Content</Tab>
                 <Tab :href="`/admin/pages/${page.data.id}/meta`">Meta</Tab>
+                <Tab :href="`/admin/pages/${page.data.id}/settings`">
+                    Settings
+                </Tab>
             </TabList>
             <TabPanels>
                 <TabPanel has-sidebar sidebar-top-position="118">
@@ -18,6 +21,9 @@
                         :page="page"
                         :full-slug="fullSlug"
                     />
+                </TabPanel>
+                <TabPanel>
+                    <PanelSettingsBody :page="page" :form="contentForm" />
                 </TabPanel>
             </TabPanels>
         </TabGroup>
@@ -43,8 +49,9 @@ import PanelMetaBody from './components/PanelMetaBody.vue';
 import PanelContentBody from './components/PanelContentBody.vue';
 import PanelContentSidebar from './components/PanelContentSidebar.vue';
 import EditSlugModal from './components/EditSlugModal.vue';
+import PanelSettingsBody from './components/PanelSettingsBody.vue';
 
-const tabs = ['content', 'meta'];
+const tabs = ['content', 'meta', 'settings'];
 
 const props = defineProps({
     page: {

--- a/publishes/pages/resources/pages/components/PanelSettingsBody.vue
+++ b/publishes/pages/resources/pages/components/PanelSettingsBody.vue
@@ -1,0 +1,59 @@
+<template>
+    <div class="p-10">
+        <span class="inline-block pb-8 text-xl font-medium">
+            Page Settings
+        </span>
+        <div class="grid grid-cols-12 gap-6">
+            <div class="col-span-full md:col-span-9">
+                <Card class="flex gap-5">
+                    <FormField no-label class="w-2/3">
+                        <Input label="Page Name" v-model="form.name" />
+                    </FormField>
+                    <FormField no-label class="w-1/3">
+                        <Input
+                            label="Page Slug"
+                            v-model="form.slug"
+                            @update:modelValue="
+                                slug => (form.slug = slugify(slug))
+                            "
+                        />
+                    </FormField>
+                </Card>
+                <Button
+                    secondary
+                    class="!bg-red-500 !text-white !border-none flex mt-4"
+                    @click="deletePage(page.data)"
+                >
+                    <IconTrash class="w-4 h-4 mr-2" />
+                    Delete Page
+                </Button>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import { defineProps, PropType } from 'vue';
+import { PageResource } from '@admin/types/resources';
+import { PageContentForm } from '@admin/types/forms';
+import { deletePage } from '@admin/modules/page';
+import {
+    Card,
+    FormField,
+    Input,
+    Button,
+    IconTrash,
+} from '@macramejs/admin-vue3';
+import { slugify } from '@admin/modules/helpers';
+
+const props = defineProps({
+    page: {
+        type: Object as PropType<PageResource>,
+        required: true,
+    },
+    form: {
+        type: Object as PropType<PageContentForm>,
+        required: true,
+    },
+});
+</script>


### PR DESCRIPTION
This PR (re) adds the page settings tab (but with content).

Currently the only things to do here are:
- edit page name
- edit page slug
- delete page

So only editing the page name is actually new 🤷‍♂️

<img width="804" alt="screenshot 19" src="https://user-images.githubusercontent.com/36259611/170051014-f64f2ee7-6219-42ee-ac54-4d306cd7fb96.png">
