### PR TITLE
Page order autosave (v2)

### DIFF
--- a/publishes/pages/resources/pages/components/PagesSidebar.vue
+++ b/publishes/pages/resources/pages/components/PagesSidebar.vue
@@ -36,23 +36,15 @@ type PageTree = Tree<Page>;
 
 const tree: PageTree = useTree<Page>(props.pages);
 
-tree.updateOnChange(() => props.pages);
-
-const queueKey = `pages.order`;
 let originalOrder = useOriginal(tree.getOrder());
 
 watch(
     tree,
     () => {
         const order = tree.getOrder();
-
-        if (originalOrder.matches(order)) {
-            saveQueue.remove(queueKey);
-        } else {
-            saveQueue.add(queueKey, async () => {
-                originalOrder.update(order);
-                Inertia.post('/admin/pages/order', { order });
-            });
+        if (!originalOrder.matches(order)) {
+            originalOrder.update(order);
+            Inertia.post('/admin/pages/order', { order });
         }
     },
     { immediate: true, deep: true }


### PR DESCRIPTION
So I just found that the change I tried in #17 is working when removing the `updateOnChange` function call for the pages tree.

And that's it basically...

Previously the problem was that changing the parameter for `updateOnChange` back to the "static" `props.pages` would not update the index when adding a new page.

Removing the `updateOnChange` however  solves all problems at once 🙃

