### PR TITLE
Fix/page resource template

### DIFF
--- a/publishes/admin/Http/Resources/PageResource.php
+++ b/publishes/admin/Http/Resources/PageResource.php
@@ -32,7 +32,7 @@ class PageResource extends JsonResource
             'name'        => $this->name,
             'slug'        => $this->slug,
             'preview_key' => $this->preview_key,
-            'template'    => $this->template,
+            'template'    => (string) $this->template,
             'parent_id'   => $this->parent_id,
 
             // dynamic

--- a/publishes/app/Models/Page.php
+++ b/publishes/app/Models/Page.php
@@ -2,17 +2,16 @@
 
 namespace App\Models;
 
-use Admin\Traits\IsPage;
-use Admin\Traits\HasFiles;
-use App\Casts\ContentCast;
-use App\Casts\PageTemplateCast;
-use App\Casts\PageAttributesCast;
-use Illuminate\Database\Eloquent\Model;
-use App\Http\Controllers\PageController;
 use Admin\Contracts\Pages\Page as PageContract;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Admin\Traits\HasFiles;
+use Admin\Traits\IsPage;
+use App\Casts\ContentCast;
+use App\Casts\PageAttributesCast;
+use App\Casts\PageTemplateCast;
+use App\Http\Controllers\PageController;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property PageTemplateCast $template
@@ -116,5 +115,19 @@ class Page extends Model implements PageContract
         $parentIds = $this->parent ? $this->parent->getTreeIds() : [];
 
         return array_merge($parentIds, [$this->id]);
+    }
+
+    /**
+     * Get the full name of the page.
+     *
+     * @return string
+     */
+    public function getFullName(): string
+    {
+        if (! $this->parent) {
+            return $this->name;
+        }
+
+        return $this->parent->getFullName().' > '.$this->name;
     }
 }


### PR DESCRIPTION
This PR changes the admin PageResource by adding a string cast to the template variable. This is necessary due to the backend not being able to interpret the template option when loading the page template.

This PR also adds a new method getFullName to the page model, which recursively returns the name of the page or its parents. This avoids an error when trying to load the links in the backend.